### PR TITLE
Modern news layout

### DIFF
--- a/includes/ucf-pegasus-list-config.php
+++ b/includes/ucf-pegasus-list-config.php
@@ -25,7 +25,8 @@ if ( ! class_exists( 'UCF_Pegasus_List_Config' ) ) {
 		 **/
 		public static function get_layouts() {
 			$layouts = array(
-				'default' => 'Default Layout'
+				'default' => 'Default Layout',
+				'modern'  => 'Modern News Layout'
 			);
 
 			$layouts = apply_filters( self::$option_prefix . 'get_layouts', $layouts );

--- a/layouts/ucf-pegasus-list-default.php
+++ b/layouts/ucf-pegasus-list-default.php
@@ -7,7 +7,7 @@ if ( ! function_exists( 'ucf_pegasus_list_display_default_before' ) ) {
 	function ucf_pegasus_list_display_default_before( $layout_before, $items, $args ) {
 		ob_start();
 	?>
-		<div class="ucf-pegasus-list">
+		<div class="ucf-pegasus-list ucf-pegasus-list-default">
 			<?php if ( $args['title'] ) : ?>
 			<h2 class="ucf-pegasus-list-title"><?php echo $args['title']; ?></h2>
 			<?php endif; ?>

--- a/layouts/ucf-pegasus-list-modern.php
+++ b/layouts/ucf-pegasus-list-modern.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Functions that define the Pegasus list "modern" layout
+ */
+
+if ( ! function_exists( 'ucf_pegasus_list_display_modern_before' ) ) {
+	function ucf_pegasus_list_display_modern_before( $layout_before, $items, $args ) {
+		ob_start();
+	?>
+		<div class="ucf-pegasus-list ucf-pegasus-modern-list">
+			<?php if ( $args['title'] ) : ?>
+			<h2 class="ucf-pegasus-list-title"><?php echo $args['title']; ?></h2>
+			<?php endif; ?>
+	<?php
+		return ob_get_clean();
+	}
+
+	add_filter( 'ucf_pegasus_list_display_modern_before', 'ucf_pegasus_list_display_modern_before', 10, 3 );
+}
+
+if ( ! function_exists( 'ucf_pegasus_list_display_modern_content' ) ) {
+	function ucf_pegasus_list_display_modern_content( $layout_content, $items, $args, $fallback_message='' ) {
+		if ( $items && ! is_array( $items ) ) { $items = array( $items ); }
+
+		ob_start();
+
+		if ( $items ) :
+
+			foreach ( $items as $item ) :
+				$issue_url   = $item->link;
+				$issue_title = $item->title->rendered;
+				$cover_story = $item->_embedded->issue_cover_story[0];
+				$cover_story_url = $cover_story->link;
+				$cover_story_title = $cover_story->title->rendered;
+				$cover_story_subtitle = $cover_story->story_subtitle;
+				$cover_story_description = $cover_story->story_description;
+				$cover_story_blurb = null;
+				$thumbnail_id = isset( $item->featured_media ) ? $item->featured_media : 0;
+				$thumbnail = null;
+				$thumbnail_url = null;
+
+				if ( $thumbnail_id !== 0 ) {
+					$thumbnail = $item->_embedded->{"wp:featuredmedia"}[0];
+					$thumbnail_url = $thumbnail->media_details->sizes->full->source_url;
+				}
+
+				if ( $cover_story_description ) {
+					$cover_story_blurb = $cover_story_description;
+				} else if ( $cover_story_subtitle ) {
+					$cover_story_blurb = $cover_story_subtitle;
+				}
+	?>
+		<div class="ucf-pegasus-issue">
+		<?php if ( $thumbnail_url ) : ?>
+			<a class="ucf-pegasus-issue-thumbnail-link" href="<?php echo $issue_url; ?>" target="_blank">
+				<img class="ucf-pegasus-issue-thumbnail" src="<?php echo $thumbnail_url; ?>" alt="<?php echo $issue_title; ?>" title="<?php echo $issue_title; ?>">
+			</a>
+			<?php endif; ?>
+			<div class="ucf-pegasus-issue-details">
+				<a class="ucf-pegasus-issue-title" href="<?php echo $issue_url; ?>" target="_blank">
+					<?php echo wptexturize( $issue_title ); ?>
+				</a>
+
+				<span class="ucf-pegasus-issue-featured-label">Featured Story</span>
+
+				<a class="ucf-pegasus-issue-cover-title" href="<?php echo $cover_story_url; ?>">
+					<?php echo wptexturize( $cover_story_title ); ?>
+				</a>
+
+				<?php if ( $cover_story_blurb ): ?>
+				<div class="ucf-pegasus-issue-cover-description">
+					<?php echo wptexturize( strip_tags( $cover_story_blurb, '<b><em><i><u><strong>' ) ); ?>
+				</div>
+				<?php endif; ?>
+
+				<a class="ucf-pegasus-issue-read-link" href="<?php echo $cover_story_url; ?>" target="_blank">
+					Read More
+				</a>
+			</div>
+		</div>
+		<?php endforeach; ?>
+
+	<?php else: ?>
+		<span class="ucf-pegasus-issue-error"><?php echo $fallback_message; ?></span>
+	<?php endif; ?>
+
+	<?php
+		return ob_get_clean();
+	}
+
+	add_filter( 'ucf_pegasus_list_display_modern_content', 'ucf_pegasus_list_display_modern_content', 10, 4 );
+}
+
+if ( ! function_exists( 'ucf_pegasus_list_display_modern_after' ) ) {
+	function ucf_pegasus_list_display_modern_after( $layout_after, $items, $args ) {
+		ob_start();
+	?>
+		</div>
+	<?php
+		return ob_get_clean();
+	}
+
+	add_filter( 'ucf_pegasus_list_display_modern_after', 'ucf_pegasus_list_display_modern_after', 10, 3 );
+}

--- a/layouts/ucf-pegasus-list-modern.php
+++ b/layouts/ucf-pegasus-list-modern.php
@@ -23,11 +23,12 @@ if ( ! function_exists( 'ucf_pegasus_list_display_modern_content' ) ) {
 		if ( $items && ! is_array( $items ) ) { $items = array( $items ); }
 
 		ob_start();
+?>
 
-		if ( $items ) :
+		<?php if ( $items ) : ?>
 
+			<?php
 			foreach ( $items as $item ) :
-				$issue_url   = $item->link;
 				$issue_title = $item->title->rendered;
 				$cover_story = $item->_embedded->issue_cover_story[0];
 				$cover_story_url = $cover_story->link;
@@ -37,11 +38,18 @@ if ( ! function_exists( 'ucf_pegasus_list_display_modern_content' ) ) {
 				$cover_story_blurb = null;
 				$thumbnail_id = isset( $item->featured_media ) ? $item->featured_media : 0;
 				$thumbnail = null;
-				$thumbnail_url = null;
+				$thumbnail_size = null;
 
 				if ( $thumbnail_id !== 0 ) {
 					$thumbnail = $item->_embedded->{"wp:featuredmedia"}[0];
-					$thumbnail_url = $thumbnail->media_details->sizes->full->source_url;
+					if ( isset( $thumbnail->media_details->sizes->{"frontpage-story-thumbnail"} ) ) {
+						$thumbnail_size = $thumbnail->media_details->sizes->{"frontpage-story-thumbnail"};
+					} else {
+						// Use 'medium' size as a fallback if
+						// 'frontpage-story-thumbnail' isn't available
+						// (e.g. for really old stories)
+						$thumbnail_size = $thumbnail->media_details->sizes->medium;
+					}
 				}
 
 				if ( $cover_story_description ) {
@@ -49,42 +57,40 @@ if ( ! function_exists( 'ucf_pegasus_list_display_modern_content' ) ) {
 				} else if ( $cover_story_subtitle ) {
 					$cover_story_blurb = $cover_story_subtitle;
 				}
-	?>
-		<div class="ucf-pegasus-issue">
-		<?php if ( $thumbnail_url ) : ?>
-			<a class="ucf-pegasus-issue-thumbnail-link" href="<?php echo $issue_url; ?>" target="_blank">
-				<img class="ucf-pegasus-issue-thumbnail" src="<?php echo $thumbnail_url; ?>" alt="<?php echo $issue_title; ?>" title="<?php echo $issue_title; ?>">
-			</a>
-			<?php endif; ?>
-			<div class="ucf-pegasus-issue-details">
-				<a class="ucf-pegasus-issue-title" href="<?php echo $issue_url; ?>" target="_blank">
-					<?php echo wptexturize( $issue_title ); ?>
-				</a>
+			?>
+			<div class="ucf-pegasus-issue media-background-container hover-parent p-3 mb-3" style="margin-left: -1rem; margin-right: -1rem;">
+				<div class="media-background hover-child-show fade" style="background-color: rgba(204, 204, 204, .25);"></div>
 
-				<span class="ucf-pegasus-issue-featured-label">Featured Story</span>
-
-				<a class="ucf-pegasus-issue-cover-title" href="<?php echo $cover_story_url; ?>">
-					<?php echo wptexturize( $cover_story_title ); ?>
-				</a>
-
-				<?php if ( $cover_story_blurb ): ?>
-				<div class="ucf-pegasus-issue-cover-description">
-					<?php echo wptexturize( strip_tags( $cover_story_blurb, '<b><em><i><u><strong>' ) ); ?>
+				<div class="media">
+					<?php if ( $thumbnail_size ) : ?>
+					<div class="d-flex w-25 mr-3" style="max-width: 150px;">
+						<img src="<?php echo $thumbnail_size->source_url; ?>" class="img-fluid" alt="" width="<?php echo $thumbnail_size->width; ?>" height="<?php echo $thumbnail_size->height; ?>">
+					</div>
+					<?php endif; ?>
+					<div class="media-body">
+						<div class="mb-2 pb-1">
+							<span class="badge badge-primary">Pegasus Magazine - <?php echo wptexturize( $issue_title ); ?></span>
+						</div>
+						<a class="d-block stretched-link h5 mb-2 pb-1" href="<?php echo $cover_story_url; ?>" style="color: inherit;">
+							<?php echo wptexturize( $cover_story_title ); ?>
+						</a>
+						<?php if ( $cover_story_blurb ): ?>
+						<div class="font-size-sm">
+							<?php echo wptexturize( strip_tags( $cover_story_blurb, '<b><em><i><u><strong>' ) ); ?>
+						</div>
+						<?php endif; ?>
+					</div>
 				</div>
-				<?php endif; ?>
-
-				<a class="ucf-pegasus-issue-read-link" href="<?php echo $cover_story_url; ?>" target="_blank">
-					Read More
-				</a>
 			</div>
+			<?php endforeach; ?>
+
+		<?php elseif ( $fallback_message ) : ?>
+		<div class="ucf-pegasus-issue-error">
+			<?php echo $fallback_message; ?>
 		</div>
-		<?php endforeach; ?>
+		<?php endif; ?>
 
-	<?php else: ?>
-		<span class="ucf-pegasus-issue-error"><?php echo $fallback_message; ?></span>
-	<?php endif; ?>
-
-	<?php
+<?php
 		return ob_get_clean();
 	}
 

--- a/layouts/ucf-pegasus-list-modern.php
+++ b/layouts/ucf-pegasus-list-modern.php
@@ -7,7 +7,7 @@ if ( ! function_exists( 'ucf_pegasus_list_display_modern_before' ) ) {
 	function ucf_pegasus_list_display_modern_before( $layout_before, $items, $args ) {
 		ob_start();
 	?>
-		<div class="ucf-pegasus-list ucf-pegasus-modern-list">
+		<div class="ucf-pegasus-list ucf-pegasus-list-modern">
 			<?php if ( $args['title'] ) : ?>
 			<h2 class="ucf-pegasus-list-title"><?php echo $args['title']; ?></h2>
 			<?php endif; ?>

--- a/ucf-pegasus-list.php
+++ b/ucf-pegasus-list.php
@@ -20,6 +20,7 @@ include_once UCF_PEGASUS_LIST__PLUGIN_DIR . 'includes/ucf-pegasus-list-common.ph
 include_once UCF_PEGASUS_LIST__PLUGIN_DIR . 'shortcodes/ucf-pegasus-list-shortcode.php';
 
 include_once UCF_PEGASUS_LIST__PLUGIN_DIR . 'layouts/ucf-pegasus-list-default.php';
+include_once UCF_PEGASUS_LIST__PLUGIN_DIR . 'layouts/ucf-pegasus-list-modern.php';
 
 
 if ( ! function_exists( 'ucf_pegasus_list_activation' ) ) {


### PR DESCRIPTION
Adds a new "modern" layout that mimics the UCF News plugin's modern layout.  Each list item focuses on the cover story for each issue, vs the issues themselves.

Note: currently, this layout uses issue thumbnails instead of the thumbnails of each cover story; this will be addressed in a future PR.